### PR TITLE
Changes TravisCI urls to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PlatIAgro Datasets
 
-[![Build Status](https://travis-ci.org/platiagro/datasets.svg)](https://travis-ci.org/platiagro/datasets)
+[![Build Status](https://travis-ci.com/platiagro/datasets.svg)](https://travis-ci.com/platiagro/datasets)
 [![codecov](https://codecov.io/gh/platiagro/datasets/branch/master/graph/badge.svg)](https://codecov.io/gh/platiagro/datasets)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Gitter](https://badges.gitter.im/platiagro/community.svg)](https://gitter.im/platiagro/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
All projects should only use travis-ci.com.