### PR TITLE
Fix HTTP code when invalid featuretypes are provided

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -40,6 +40,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    - name: Build docker image
-      run: |
-        docker build -t "platiagro/datasets:$GITHUB_SHA" .
+    - name: Build and push image
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: registry.hub.docker.com
+        repository: platiagro/datasets
+        tags: 0.0.2

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -46,9 +46,15 @@ def create_dataset(files):
 
     # checks if the post request has the 'featuretypes' part
     if "featuretypes" in files:
-        ftype_file = files["featuretypes"]
-        featuretypes = list(map(lambda s: s.strip().decode("utf8"), ftype_file.readlines()))
-        validate_featuretypes(featuretypes)
+        try:
+            ftype_file = files["featuretypes"]
+            featuretypes = list(map(lambda s: s.strip().decode("utf8"), ftype_file.readlines()))
+            validate_featuretypes(featuretypes)
+        except ValueError as e:
+            raise BadRequest(str(e))
+
+        if len(columns) != len(featuretypes):
+            raise BadRequest("featuretypes must be the same length as the DataFrame columns")
     else:
         featuretypes = infer_featuretypes(df)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,11 +56,13 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {"message": "No file part"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
 
             rv = c.post("/datasets", data={"file": (BytesIO(), "")})
             result = rv.get_json()
             expected = {"message": "No selected file"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -74,6 +76,8 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {
                 "message": "featuretype must be one of DateTime, Numerical, Categorical"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -82,6 +86,8 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {
                 "message": "featuretypes must be the same length as the DataFrame columns"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -103,6 +109,7 @@ class TestApi(TestCase):
             self.assertIn("name", result)
             del result["name"]
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)
 
             rv = c.post("/datasets", data={
                 "file": self.boston_file(),
@@ -132,6 +139,7 @@ class TestApi(TestCase):
             self.assertIn("name", result)
             del result["name"]
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -152,6 +160,7 @@ class TestApi(TestCase):
             self.assertIn("name", result)
             del result["name"]
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)
 
     def test_get_dataset(self):
         with app.test_client() as c:
@@ -159,6 +168,7 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {"message": "The specified dataset does not exist"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 404)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -183,6 +193,7 @@ class TestApi(TestCase):
             self.assertIn("name", result)
             del result["name"]
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)
 
     def test_list_columns(self):
         with app.test_client() as c:
@@ -190,6 +201,7 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {"message": "The specified dataset does not exist"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 404)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -207,6 +219,7 @@ class TestApi(TestCase):
                 {"name": "col5", "featuretype": "Categorical"},
             ]
             self.assertListEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)
 
     def test_update_column(self):
         with app.test_client() as c:
@@ -216,6 +229,7 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {"message": "The specified dataset does not exist"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 404)
 
             rv = c.post("/datasets", data={
                 "file": self.iris_file(),
@@ -228,6 +242,7 @@ class TestApi(TestCase):
             result = rv.get_json()
             expected = {"message": "The specified column does not exist"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 404)
 
             rv = c.patch("/datasets/{}/columns/col0".format(name), json={
                 "featuretype": "Invalid"
@@ -236,6 +251,7 @@ class TestApi(TestCase):
             expected = {
                 "message": "featuretype must be one of DateTime, Numerical, Categorical"}
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
 
             rv = c.patch("/datasets/{}/columns/col0".format(name), json={
                 "featuretype": "Numerical"
@@ -246,3 +262,4 @@ class TestApi(TestCase):
                 "featuretype": "Numerical"
             }
             self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 200)


### PR DESCRIPTION
Now returns HTTP code 400 (Bad Request); Previously was returning
500 (Internal Server Error).
Updates unit tests to check HTTP status in all requests.