### PR TITLE
Add Metadata for All Files

### DIFF
--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -58,7 +58,7 @@ def create_dataset(files: Dict[str, IO]) -> Dict[str, Any]:
     except Exception:
         # if read fails, then uploads raw file
         file.seek(0, SEEK_SET)
-        save_dataset(name, file)
+        save_dataset(name, file, metadata={"original-filename": file.filename})
         return {"name": name, "filename": file.filename}
 
     columns = df.columns.values.tolist()


### PR DESCRIPTION
- whenever a file cannot be converted to `pd.DataFrame`, add the "original-filename" property to the metadata file