### PR TITLE
Stamps git commit SHA and BRANCH on docker image

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -58,8 +58,8 @@ jobs:
           - async/await NÃO EXISTEM no Python3.6
           - Métodos que são chamados de outros arquivos `.py` **DEVEM TER Docstring**.
           - Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
-    - name: Set Docker TAG
-      id: var
+    - name: Set output variables
+      id: vars
       run: |
         echo ${{ github.ref }}
         if [ ${{ github.ref }} = "refs/heads/master" ]; then
@@ -67,6 +67,8 @@ jobs:
         else
           echo ::set-output name=TAG::0.1.0-SNAPSHOT
         fi
+        echo ::set-output name=BRANCH::${{ github.ref }}
+        echo ::set-output name=COMMIT::${{ github.sha }}
     - uses: actions/checkout@v2
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
@@ -108,4 +110,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         registry: registry.hub.docker.com
         repository: platiagro/datasets
-        tags: ${{ steps.var.outputs.TAG }}
+        tags: ${{ steps.vars.outputs.TAG }}
+        build_args: COMMIT=${{ steps.vars.outputs.COMMIT }},BRANCH=${{ steps.vars.outputs.BRANCH }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM python:3.6-buster
 
+LABEL maintainer="fabiol@cpqd.com.br"
+
+# Stamps the commit SHA into the labels and ENV vars
+ARG BRANCH="master"
+ARG COMMIT=""
+LABEL branch=${BRANCH}
+LABEL commit=${COMMIT}
+ENV COMMIT=${COMMIT}
+ENV BRANCH=${BRANCH}
+
 COPY ./requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt


### PR DESCRIPTION
Uses ---build-args to pass the commit_sha and branch, and saves
their values in LABEL and ENV vars.