### PR TITLE
Replaces relative imports by absolute imports

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -58,6 +58,8 @@ jobs:
           - async/await NÃO EXISTEM no Python3.6
           - Métodos que são chamados de outros arquivos `.py` **DEVEM TER Docstring**.
           - Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+          - Usar sempre import absoluto.
+            ex: `from datasets.samples import init_datasets` (BOM), `from .samples import init_datasets` (RUIM)
     - name: Set output variables
       id: vars
       run: |

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -7,11 +7,11 @@ from flask import Flask, request, jsonify, make_response
 from flask_cors import CORS
 from werkzeug.exceptions import BadRequest, NotFound, InternalServerError
 
-from .columns import list_columns, update_column
-from .datasets import list_datasets, create_dataset, create_google_drive_dataset, \
+from datasets.columns import list_columns, update_column
+from datasets.datasets import list_datasets, create_dataset, create_google_drive_dataset, \
     get_dataset, get_featuretypes, patch_dataset
-from .samples import init_datasets
-from .utils import to_snake_case
+from datasets.samples import init_datasets
+from datasets.utils import to_snake_case
 
 app = Flask(__name__)
 

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -11,12 +11,13 @@ import platiagro
 from chardet.universaldetector import UniversalDetector
 from googleapiclient.discovery import build
 from googleapiclient.http import HttpError, MediaIoBaseDownload
+from oauth2client import client, GOOGLE_TOKEN_URI
 from pandas.io.common import infer_compression
 from platiagro import load_dataset, save_dataset, stat_dataset, update_dataset_metadata
 from platiagro.featuretypes import infer_featuretypes, validate_featuretypes
-from oauth2client import client, GOOGLE_TOKEN_URI
 from werkzeug.exceptions import BadRequest, NotFound
-from .utils import data_pagination
+
+from datasets.utils import data_pagination
 
 DATASET_NOT_FOUND_ERROR = "The specified dataset does not exist"
 

--- a/datasets/utils.py
+++ b/datasets/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 from itertools import zip_longest
+
 from werkzeug.exceptions import NotFound
 
 


### PR DESCRIPTION
This was changed because PEP 8 encourages absolute imports:
See https://www.python.org/dev/peps/pep-0008/ for further details.

Also added a instruction to use absolute imports in code-review tips.