### PR TITLE
[PLATIA-2245]fix/file-upload-bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -87,10 +87,11 @@ async def handle_post_datasets(
                 return create_dataset(file)
             except Exception as e:
                 logging.info(e)
+                print(e)
                 time.sleep(1)
                 i = i + 1
 
-        raise InternalServerError("Not able to handle file upload")
+    #  raise InternalServerError("Not able to handle file upload")
 
     try:
         # request methods in fastapi are async by implementation

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -3,6 +3,8 @@
 import argparse
 import os
 import sys
+import tempfile
+
 from typing import Optional
 
 import asyncio
@@ -11,23 +13,34 @@ import uvicorn
 from fastapi import FastAPI, Request, File, UploadFile
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 
 from datasets import __version__
 from datasets.columns import list_columns, update_column
-from datasets.datasets import list_datasets, create_dataset, create_google_drive_dataset, \
-    get_dataset, download_dataset, get_featuretypes, patch_dataset
+from datasets.datasets import (
+    list_datasets,
+    create_dataset,
+    create_google_drive_dataset,
+    get_dataset,
+    download_dataset,
+    get_featuretypes,
+    patch_dataset,
+)
 from datasets.utils import to_snake_case
 from datasets.exceptions import BadRequest, NotFound, InternalServerError
-
 
 
 app = FastAPI(
     title="PlatIAgro Datasets",
     description="These are the docs for PlatIAgro Datasets API."
-                "The endpoints below are usually accessed by the PlatIAgro Web-UI",
+    "The endpoints below are usually accessed by the PlatIAgro Web-UI",
     version=__version__,
 )
+
+
+class DatasetPostSchema(BaseModel):
+    file: bytes = File(None)
 
 
 @app.get("/", response_class=PlainTextResponse)
@@ -55,39 +68,41 @@ async def handle_list_datasets():
 
 
 @app.post("/datasets")
-def handle_post_datasets(request: Request, file: Optional[UploadFile] = File(None)):
+async def handle_post_datasets(
+    request: Request,
+    file: Optional[UploadFile] = File(None),
+):
     """
     Handles POST requests to /datasets.
 
     obs: As you can see, this function instead of being asynchronous is synchronous.
     This change was necessary to correct a bug, in which the file, which is by the way
-    a SpooledTemporaryFile, was losing from memory, and because of this, MINIOCLIENT was 
+    a SpooledTemporaryFile, was losing from memory, and because of this, MINIOCLIENT was
     unable to perform the put object command. Putting as synchronous solved this problem,
-    probably the error is due to the way the asynchronous function is being erroneously 
+    probably the error is due to the way the asynchronous function is being erroneously
     used in synchronous situations. Follow the link regarding file upload using FastAPI:
-    
+
     https://github.com/tiangolo/fastapi/blob/master/docs/en/docs/tutorial/request-files.md#:~:text=File%20parameters%20with%20UploadFile
-    
+
     Returns
     -------
     str
     """
     if file:
-        return create_dataset(file)
+        filename = file.filename
+        with tempfile.TemporaryFile() as f:
+            return create_dataset(f, filename=filename)
 
     try:
         # request methods in fastapi are async by implementation
         # so, to be able to use inside a sync function we had to use this way
         kwargs = asyncio.run(request.json())
-        
+
         kwargs = {to_snake_case(k): v for k, v in kwargs.items()}
         if kwargs:
             return create_google_drive_dataset(**kwargs)
     except RuntimeError:
         raise BadRequest("No file part.")
-        
-
-
 
 
 @app.get("/datasets/{name}")
@@ -176,9 +191,12 @@ async def handle_get_featuretypes(dataset: str):
     str
     """
     featuretypes = get_featuretypes(dataset)
-    headers = {"Content-Type": "text/plain",
-               "Content-Disposition": "attachment; filename=featuretypes.txt"}
+    headers = {
+        "Content-Type": "text/plain",
+        "Content-Disposition": "attachment; filename=featuretypes.txt",
+    }
     return Response(content=featuretypes, headers=headers)
+
 
 @app.get("/datasets/{name}/downloads", response_class=StreamingResponse)
 async def handle_download_dataset(name: str):
@@ -195,7 +213,7 @@ async def handle_download_dataset(name: str):
         Streaming response with dataset content.
     """
     streaming_response = download_dataset(name)
-    return streaming_response   
+    return streaming_response
 
 
 @app.exception_handler(BadRequest)
@@ -223,6 +241,7 @@ def enable_cors():
     """
     Enables CORS preflight requests.
     """
+
     @app.options("/{rest_of_path:path}")
     async def preflight_handler(request: Request, rest_of_path: str) -> Response:
         """
@@ -230,7 +249,9 @@ def enable_cors():
         """
         response = Response()
         response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Methods"] = "POST, GET, DELETE, PATCH, OPTIONS"
+        response.headers[
+            "Access-Control-Allow-Methods"
+        ] = "POST, GET, DELETE, PATCH, OPTIONS"
         response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
         return response
 
@@ -241,7 +262,9 @@ def enable_cors():
         """
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Methods"] = "POST, GET, DELETE, PATCH, OPTIONS"
+        response.headers[
+            "Access-Control-Allow-Methods"
+        ] = "POST, GET, DELETE, PATCH, OPTIONS"
         response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
         return response
 
@@ -256,10 +279,16 @@ def parse_args(args):
         description="Datasets API",
     )
     parser.add_argument(
-        "--host", type=str, default="127.0.0.1", help="Host for HTTP server (default: 127.0.0.1)",
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for HTTP server (default: 127.0.0.1)",
     )
     parser.add_argument(
-        "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)",
+        "--port",
+        type=int,
+        default=8080,
+        help="Port for HTTP server (default: 8080)",
     )
     return parser.parse_args(args)
 

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -87,6 +87,7 @@ async def handle_post_datasets(
                 return create_dataset(file)
             except Exception as e:
                 logging.info(e)
+                time.sleep(1)
                 i = i + 1
 
         raise InternalServerError("Not able to handle file upload")

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -99,7 +99,7 @@ async def handle_post_datasets(
     try:
         # request methods in fastapi are async by implementation
         # so, to be able to use inside a sync function we had to use this way
-        kwargs = asyncio.run(request.json())
+        kwargs = request.json()
 
         kwargs = {to_snake_case(k): v for k, v in kwargs.items()}
         if kwargs:

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -99,7 +99,7 @@ async def handle_post_datasets(
     try:
         # request methods in fastapi are async by implementation
         # so, to be able to use inside a sync function we had to use this way
-        kwargs = request.json()
+        kwargs = await request.json()
 
         kwargs = {to_snake_case(k): v for k, v in kwargs.items()}
         if kwargs:

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -80,18 +80,21 @@ async def handle_post_datasets(
     -------
     str
     """
-    i = 0
+    retries = 0
     if file:
-        while i < MAX_RETRIES:
+        while retries < MAX_RETRIES:
             try:
                 return create_dataset(file)
             except Exception as e:
                 logging.info(e)
-                print(e)
+                logging.info(f"Something went wrong while uploading the file")
+                logging.info(f"Retrying processing upload")
+                logging.info(f"retries: {retries} of {MAX_RETRIES}")
+                # let's wait 1 sec before tryng again!
                 time.sleep(1)
-                i = i + 1
+                retries = retries + 1
 
-    #  raise InternalServerError("Not able to handle file upload")
+        raise InternalServerError("Not able to handle file upload")
 
     try:
         # request methods in fastapi are async by implementation

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -10,15 +10,25 @@ from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, File, Request, UploadFile
-from fastapi.responses import (JSONResponse, PlainTextResponse, Response,
-                               StreamingResponse)
+from fastapi.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    Response,
+    StreamingResponse,
+)
 from pydantic import BaseModel
 
 from datasets import __version__
 from datasets.columns import list_columns, update_column
-from datasets.datasets import (create_dataset, create_google_drive_dataset,
-                               download_dataset, get_dataset, get_featuretypes,
-                               list_datasets, patch_dataset)
+from datasets.datasets import (
+    create_dataset,
+    create_google_drive_dataset,
+    download_dataset,
+    get_dataset,
+    get_featuretypes,
+    list_datasets,
+    patch_dataset,
+)
 from datasets.exceptions import BadRequest, InternalServerError, NotFound
 from datasets.utils import to_snake_case
 
@@ -75,6 +85,7 @@ async def handle_post_datasets(
             return create_dataset(file)
         except Exception as e:
             logging.info(e)
+            print(e)
             raise InternalServerError("Not able to handle file upload")
 
     try:

--- a/datasets/api.py
+++ b/datasets/api.py
@@ -80,13 +80,16 @@ async def handle_post_datasets(
     -------
     str
     """
+    i = 0
     if file:
-        try:
-            return create_dataset(file)
-        except Exception as e:
-            logging.info(e)
-            print(e)
-            raise InternalServerError("Not able to handle file upload")
+        while i < MAX_RETRIES:
+            try:
+                return create_dataset(file)
+            except Exception as e:
+                logging.info(e)
+                i = i + 1
+
+        raise InternalServerError("Not able to handle file upload")
 
     try:
         # request methods in fastapi are async by implementation

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -44,7 +44,7 @@ def list_datasets():
     return [{"name": name} for name in datasets]
 
 
-def create_dataset(file_object):
+def create_dataset(file_object, filename):
     """
     Creates a new dataset in our object storage.
 
@@ -65,10 +65,8 @@ def create_dataset(file_object):
     """
     if isinstance(file_object, dict):
         file = file_object["file"]
-        filename = file.filename
     else:
-        file = file_object.file
-        filename = file_object.filename
+        file = file_object
 
     # if user does not select file, the browser also
     # submits an empty part without filename

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -100,7 +100,7 @@ def create_dataset(file_object):
             "original-filename": filename,
             "total": len(df.index),
         }
-
+        buffer.seek(0, SEEK_SET)
         save_dataset(name, buffer, metadata=metadata)
 
     columns = [

--- a/datasets/datasets.py
+++ b/datasets/datasets.py
@@ -71,6 +71,7 @@ def create_dataset(file_object):
         file = file_object.file
         filename = file_object.filename
 
+    file.seek(0, SEEK_SET)
     with NamedTemporaryFile() as buffer:
         shutil.copyfileobj(file, buffer)
 


### PR DESCRIPTION
PR referente ao jira: https://jira.cpqd.com.br/browse/PLATIA-2245

Problema: O arquivo não conseguia ser devidamente subido ao storage por conta de erro de operações I/O

Análise: Ao subir o arquivo a memória RAM desempenha um importante papel, mas devido a problemas de implementação somados a volatilidade de manipulação de memória RAM tínhamos perda de referência durante o processo de manipulação do arquivo. Por conta disto, havia falhar nas operações de I/O

Solução: Colocar a manipulação de arquivo dentro de um contexto como forma de diminuir a ocorrência de erros relacionado a manipulação do arquivo. Somado a isto, fazer uma lógica de retry caso ocorra algum erro.

@dfvneto @alanmsant2 
